### PR TITLE
Fix DELETE rquest: add header content-length for body in delete method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ const sendNodeAPIRequest = (path, method, headers, body) => {
         _send()
       })
     } else {
-      if (method === 'DELETE' && body) {
+      if (body && !options.headers['content-length']) {
         const Buffer = require('buffer').Buffer
         options.headers['content-length'] = Buffer.byteLength(body)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,11 @@ const sendNodeAPIRequest = (path, method, headers, body) => {
         _send()
       })
     } else {
+      if (method === 'DELETE' && body) {
+        const Buffer = require('buffer').Buffer
+        options.headers['content-length'] = Buffer.byteLength(body)
+      }
+
       _send()
     }
   })


### PR DESCRIPTION
The Buffer class is global within Node.js. But I used `require('buffer')` to make possible polyfilling of it e.g. in React-Native.