### PR TITLE
UMD Build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,10 +13,9 @@ ExternalModule.prototype.getSourceForCommonJsExternal = function(moduleAndSpecif
     //one of these is problem with ReactNative http://support.backendless.com/topic/latest-npm-version-4-1-6-not-working-with-react-native
     return [
       'throw new Error(\'',
-      `NodeJs package "${moduleAndSpecifiers}" is not included to "dist" build. `,
-      'Do not use the file in NodeJs environment. ',
-      'You should use files from "lib" directory instead. ',
-      'If you have some problems with it or any questions please create a new support topic here http://support.backendless.com/ ',
+      'This Backendless JS SDK assembly is not intended for Node.js environment. ' +
+      'You should use "lib" folder modules instead. ' +
+      'For any questions please contact as at http://support.backendless.com/',
       '\')'
     ].join('');
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,29 @@
 'use strict';
 
+const ExternalModule = require('webpack/lib/ExternalModule')
 const webpack = require('webpack')
+
+const nativeExternalModuleGetSourceForCommonJsExternal = ExternalModule.prototype.getSourceForCommonJsExternal
+
+const externalNodeModules = ['url', 'http', 'https', 'stream', 'form-data', 'buffer']
+
+ExternalModule.prototype.getSourceForCommonJsExternal = function(moduleAndSpecifiers) {
+  if (typeof moduleAndSpecifiers === 'string' && externalNodeModules.includes(moduleAndSpecifiers)) {
+    //we must not include external NodeJs packages to "dist" build by several reasons,
+    //one of these is problem with ReactNative http://support.backendless.com/topic/latest-npm-version-4-1-6-not-working-with-react-native
+    return [
+      'throw new Error(\'',
+      `NodeJs package "${moduleAndSpecifiers}" is not included to "dist" build. `,
+      'Do not use the file in NodeJs environment. ',
+      'You should use files from "lib" directory instead. ',
+      'If you have some problems with it or any questions please create a new support topic here http://support.backendless.com/ ',
+      '\')'
+    ].join('');
+  }
+
+  return nativeExternalModuleGetSourceForCommonJsExternal.apply(this, arguments)
+}
+
 const isProd = process.env.NODE_ENV === 'production'
 const uglify = new webpack.optimize.UglifyJsPlugin({
   compressor: {
@@ -19,23 +42,19 @@ const uglify = new webpack.optimize.UglifyJsPlugin({
   sourceMap : true
 })
 
-function ignoreRequiresFor(packages) {
-  return function(context, moduleName, callback) {
-    if (packages.includes(moduleName)) {
-      return callback(null, `commonjs ${moduleName}`);
-    }
-
-    callback();
-  }
-}
-
 module.exports = {
 
   devtool: 'source-map',
 
   target: 'web',
 
-  externals: [ignoreRequiresFor(['url', 'http', 'https', 'stream', 'form-data', 'buffer'])],
+  externals: function(context, moduleName, callback) {
+    if (externalNodeModules.includes(moduleName)) {
+      return callback(null, `commonjs ${moduleName}`);
+    }
+
+    callback();
+  },
 
   module: {
     rules: [


### PR DESCRIPTION
- "dist" build should not be used only in Nodejs env, so we don't need to keep `require(<nativeNodeModule>)` in the build 
- fix problem with ReactNative http://support.backendless.com/topic/latest-npm-version-4-1-6-not-working-with-react-native

now the build looks like:

```
...

/***/ }),
/* 5 */
/***/ (function(module, exports) {

throw new Error('This Backendless JS SDK assembly is not intended for Node.js environment You should use "lib" folder modules instead. For any questions please contact as at http://support.backendless.com/')

/***/ }),
/* 6 */
/***/ (function(module, exports) {

throw new Error('This Backendless JS SDK assembly is not intended for Node.js environment You should use "lib" folder modules instead. For any questions please contact as at http://support.backendless.com/')

/***/ }),
/* 7 */
/***/ (function(module, exports) {

throw new Error('This Backendless JS SDK assembly is not intended for Node.js environment You should use "lib" folder modules instead. For any questions please contact as at http://support.backendless.com/')

/***/ }),
/* 8 */
/***/ (function(module, exports) {

throw new Error('This Backendless JS SDK assembly is not intended for Node.js environment You should use "lib" folder modules instead. For any questions please contact as at http://support.backendless.com/')

/***/ }),
/* 9 */
/***/ (function(module, exports) {

throw new Error('This Backendless JS SDK assembly is not intended for Node.js environment You should use "lib" folder modules instead. For any questions please contact as at http://support.backendless.com/')

/***/ })
...
```