### PR TITLE
Fix (query method): wrong type of `queryParams` in jsDoc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -244,7 +244,7 @@ class Request {
   }
 
   /**
-   * @param {String} queryParams
+   * @param {Object} queryParams
    * @returns {Request}
    */
   query(queryParams) {


### PR DESCRIPTION
`queryParams` argument should be an object, not a string, as is mistakenly expected.